### PR TITLE
Improve templates, unique CSS

### DIFF
--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8">
+    <title>Admin {{ config['TITLE'] }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" type="image/x-icon" href="{{ url_for('static', filename='uploads/favicon.ico') }}">
+
+    <!-- CSS Plugins -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/bootstrap.min.css') }}">
+  </head>
+
+  <body style="align-items: center;">
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert-container">
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert" style="position: relative; margin-bottom: 10px;">
+              {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+          </div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    {% block body %}{% endblock %}
+
+    <!-- JS Plugins -->
+    <script src="{{ url_for('static', filename='js/vendor/bootstrap.min.js') }}"></script>
+  </body>
+
+</html>

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -1,7 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'admin/index.html' %}
 
-{% block body %}
+{% block page %}
 
-  {% include 'admin/navbar.html' %}
+  <h1>Admin</h1>
 
 {% endblock %}

--- a/app/templates/admin/design.html
+++ b/app/templates/admin/design.html
@@ -2,6 +2,11 @@
 
 {% block page %}
 
+  <div class="d-flex align-items-center justify-content-center mt-4">
+    <h2>{{ screen.upper() }} PAGE</h2>
+  </div>
   {% include 'admin/design/colors.html' %}
+  <br>
+  {% include 'admin/design/logo.html' %}   
 
 {% endblock %}

--- a/app/templates/admin/design.html
+++ b/app/templates/admin/design.html
@@ -1,8 +1,6 @@
-{% extends 'base.html' %}
+{% extends 'admin/index.html' %}
 
-{% block body %}
-
-  {% include 'admin/navbar.html' %}
+{% block page %}
 
   {% include 'admin/design/colors.html' %}
 

--- a/app/templates/admin/design/colors.html
+++ b/app/templates/admin/design/colors.html
@@ -1,32 +1,35 @@
-<section class="contact__section section--padding">
-  <div class="container">
-    <div class="section__heading text-center mb-40">
-      <span class="section__heading--subtitle">{{ 'some text description' }}</span>
-      <h2 class="section__heading--maintitle">{{ screen.upper() }}</h2>
+<div class="container d-flex flex-wrap text-center">
+  <div class="row w-100">
+    <div class="d-flex align-items-center justify-content-center mt-4">
+      <h2>{{ screen.upper() }} PAGE</h2>
     </div>
-    <div class="main__contact--area position__relative">
-      <div class="contact__form">
-        <h3 class="contact__form--title mb-40">Color Palet</h3>
-        <form class="contact__form--inner" action="{{ url_for('admin.colors') }}" method="POST">
+    <button class="btn btn-dark dropdown-toggle" type="button" data-bs-toggle="collapse"
+      data-bs-target="#colorPaletteForm" aria-controls="colorPaletteForm">
+      <h3>Color Palette</h3>
+    </button>
+    <div class="col-12">
+      <div class="collapse" id="colorPaletteForm">
+        <form class="mt-3" action="{{ url_for('admin.colors') }}" method="POST">
           {{ colors_form.csrf_token }}
           <div class="row">
             {% for key in colors_form.__dict__ %}
               {% if 'color' in key %}
-                <div class="col-lg-6 col-md-6">
-                  <div class="contact__form--list mb-20">
-                    <label class="contact__form--label" for="{{ key }}">{{ key }}</label>
-                    <input class="contact__form--input" name="{{ key }}" id="{{ key }}"
-                      placeholder="{{ g.config[key.upper()] }}" type="text"
+                <div class="col-sm-6">
+                  <div class="form-group">
+                    <label for="{{ key }}">{{ key }}</label>
+                    <input name="{{ key }}" id="{{ key }}" type="text"
+                      placeholder="{{ g.config[key.upper()] }}"
                       value="{{ g.config[key.upper()] }}"
+                      class="form-control"
                       style="background-color: {{ g.config[key.upper()] }};">
                   </div>
                 </div>
               {% endif %}
             {% endfor %}
           </div>
-          <button class="btn-dark" type="submit"><span>Submit Now</span></button>  
+          <button type="submit" class="btn btn-dark mt-3">Submit</button>
         </form>
       </div>
     </div>
   </div>
-</section>
+</div>

--- a/app/templates/admin/design/colors.html
+++ b/app/templates/admin/design/colors.html
@@ -1,8 +1,5 @@
 <div class="container d-flex flex-wrap text-center">
   <div class="row w-100">
-    <div class="d-flex align-items-center justify-content-center mt-4">
-      <h2>{{ screen.upper() }} PAGE</h2>
-    </div>
     <button class="btn btn-dark dropdown-toggle" type="button" data-bs-toggle="collapse"
       data-bs-target="#colorPaletteForm" aria-controls="colorPaletteForm">
       <h3>Color Palette</h3>

--- a/app/templates/admin/design/colors.html
+++ b/app/templates/admin/design/colors.html
@@ -1,5 +1,5 @@
-<div class="container d-flex flex-wrap text-center">
-  <div class="row w-100">
+<div class="container text-center">
+  <div class="row">
     <button class="btn btn-dark dropdown-toggle" type="button" data-bs-toggle="collapse"
       data-bs-target="#colorPaletteForm" aria-controls="colorPaletteForm">
       <h3>Color Palette</h3>

--- a/app/templates/admin/design/logo.html
+++ b/app/templates/admin/design/logo.html
@@ -1,5 +1,5 @@
-<div class="container d-flex flex-wrap text-center">
-  <div class="row w-100">
+<div class="container text-center">
+  <div class="row">
     <button class="btn btn-dark dropdown-toggle" type="button" data-bs-toggle="collapse"
       data-bs-target="#logoForm" aria-controls="logoForm">
       <h3>Logo</h3>

--- a/app/templates/admin/design/logo.html
+++ b/app/templates/admin/design/logo.html
@@ -1,0 +1,22 @@
+<div class="container d-flex flex-wrap text-center">
+  <div class="row w-100">
+    <button class="btn btn-dark dropdown-toggle" type="button" data-bs-toggle="collapse"
+      data-bs-target="#logoForm" aria-controls="logoForm">
+      <h3>Logo</h3>
+    </button>
+    <div class="col-12">
+      <div class="collapse border border-dark p-3 m-3" id="logoForm">
+        <form action={{ url_for('admin.upload_logo') }} method='POST' enctype='multipart/form-data'>
+          <div class="form-group">
+            <label for="logo">Choose an image</label>
+            <div class="custom-file">
+              <input type="file" class="custom-file-input" id="logo" name="logo" accept="image/png, image/gif, image/jpeg">
+              <label class="custom-file-label" for="logo">Choose file</label>
+            </div>
+          </div>
+          <button type="submit" class="btn btn-dark">Upload</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -1,0 +1,10 @@
+{% extends 'admin/base.html' %}
+
+{% block body %}
+
+  {% include 'admin/navbar.html' %}
+
+  {% block page %}
+  {% endblock %}
+
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,7 +11,6 @@
     <!-- CSS Plugins -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/plugins/swiper-bundle.min.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/plugins/glightbox.min.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/bootstrap.min.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
 
     <!-- Custom Style CSS -->


### PR DESCRIPTION
- 🚀 feat(templates): add admin base template 🔥 chore(templates): remove bootstrap.min.css from base template
- 🎨 style(admin): refactor admin templates to use a common base template
- 🎨 style(colors.html): refactor color palette form to use Bootstrap classes and improve readability
- 🎨 style(design.html): add logo to design page and center page title 🎨 style(colors.html): remove duplicate page title from colors page
- ✨ feat(logo.html): add logo upload form to admin panel
- ♻️ refactor(templates): remove unnecessary classes from color and logo templates
Closes #11 
